### PR TITLE
fix: Update back-of-wallet text to be full width

### DIFF
--- a/generate-wallet.html
+++ b/generate-wallet.html
@@ -10109,13 +10109,8 @@ Bitcoin.Util = {
 
 		/* Back side */
 		#backText { position: absolute; margin-top: 73px; left: 260px; width: 600px; font-size: 8px; }
-		#backText #backPaperWallet { position: absolute; margin-left: 202px; color: #fb9300; font-size: 11px; text-transform: uppercase; font-style: italic; }
-		#backText #backAmount { position: absolute; margin-left: 421px; margin-top: 7px; color: #666666;}
-		#backText #backDate { position: absolute; margin-left: 558px; margin-top: 7px; color: #666666; }
-		#backText #backLines { position: absolute; margin-left: 416px; margin-top: 1px; }
-		#backText #backLines p { border-bottom: 1px dotted #999; line-height: 11px; width: 174px;}
-		#backText #backNotes { position: absolute; margin-left: 421px; margin-top: 105px; color: #666666; }
-		#backText #backLongText { position: absolute; margin-left: 200px; width: 210px; margin-top: 16px; font-size: 8px;}
+		#backText #backPaperWallet { position: absolute; margin-left: 202px; color: #fb9300; font-size: 16px; text-transform: uppercase; font-style: italic; font-weight: bold;}
+		#backText #backLongText { position: absolute; margin-left: 200px; width: 400px; margin-top: 25px; font-size: 12px;}
 		#backText #backLongText ul { margin: 0 0 0 14px; padding: 0; list-style: square outside none; }
 		#backText #backLongText li { margin: 0; padding: 0 0 3px 0; }
 		#backText #backLongText li strong { font-weight: 400; color: red; }
@@ -10128,8 +10123,8 @@ Bitcoin.Util = {
 		#backText #backSealSmall { position: absolute; margin: 53px 0 0 0; padding: 0 0 0 0; z-index: 1200; width: 105px; 
 		font-family: ubuntu_mono_bold, Arial, Helvetica, sans-serif; text-align: center; font-size: 10px; letter-spacing: .1em; color: #22461b;
 		text-shadow: rgb(255, 255, 255) 1px 1px 1px }
-		#backText #backCustomMessageEntry { background-color: #EEE; width: 195px; height: 150px; font-size: 10px; } 
-		#backText #backCustomMessage { display: none; position: absolute; overflow: hidden; margin-left: 210px; width: 195px; margin-top: 20px; font-size: 11px; line-height: 15px; height: 150px; }
+		#backText #backCustomMessageEntry { background-color: #EEE; width: 380px; height: 150px; font-size: 12px; } 
+		#backText #backCustomMessage { display: none; position: absolute; overflow: hidden; margin-left: 210px; width: 400px; margin-top: 20px; font-size: 12px; line-height: 15px; height: 160px; }
 
 		.nicerButton { /* thanks http://www.cssbuttongenerator.com */
 			-moz-box-shadow:inset 0px 1px 0px 0px #c1ed9c;
@@ -10703,16 +10698,6 @@ Find your scissors! The final step is to cut out your wallet, fold it, and seal 
                        </select>
 
                         </div>
-                        
-                        <div style="float: left; margin: 0 0 0 50px;">
-                           <input type="checkbox" checked id="backTextCheckbox2" 
-                   			 onClick="var toggleStatus = (this.checked ? 'block' : 'none'); 				
-                              document.getElementById('backAmount').style.display=toggleStatus;
-                              document.getElementById('backDate').style.display=toggleStatus;
-                              document.getElementById('backNotes').style.display=toggleStatus;
-                              document.getElementById('backLines').style.display=toggleStatus;">
-                              Include notes area
-                         </div>
                 </div><!-- backTextControl -->
 			</div><!-- end commands -->
 
@@ -10720,10 +10705,6 @@ Find your scissors! The final step is to cut out your wallet, fold it, and seal 
 					<div id="backSeal"><p id="backSealBig">1000</p><p id="backSealSmall">mBTC</p><img src="images/front-seal.png" width="105" height="78"></div>
                     
                     <div id="backPaperWallet"></div>
-                	<div id="backAmount"></div>
-                	<div id="backDate"></div>
-                	<div id="backNotes"></div>
-                    <div id="backLines"><p>&nbsp;</p><p>&nbsp;</p><p>&nbsp;</p><p>&nbsp;</p><p>&nbsp;</p></div>
                     
                     <div id="backCustomMessage">
                     	<div id="backCustomMessageContent" style="display: none;"></div>
@@ -13432,11 +13413,8 @@ function setDesign (whichDesign, isOnLoad, whichLanguage) {
 			privateKey: "PRIVATE KEY",
 			walletImportFormat: "WALLET IMPORT FORMAT",
 			withdraw: "PRIVATE KEY / WITHDRAW",
-			backLongTextFontSize: "9px",
+			backLongTextFontSize: "12px",
 			backPaperWallet: "BITCOIN PAPER WALLET",
-			backAmount: "Amount Added",
-			backDate: "Date",
-			backNotes: "Notes:",
 			backInst1: "<strong>NEVER</strong> deposit additional funds to this paper wallet! Whoever created the wallet has seen the private keys & can empty this wallet at any time!",
 			backInst2: "Verify your balance by searching for the public address using a service such as blockchain.info",
 			backInst3: "<strong>Do not reveal the private key</strong> until you are ready to import the balance on this wallet to a bitcoin client, exchange, or online wallet.",
@@ -13475,9 +13453,6 @@ function setDesign (whichDesign, isOnLoad, whichLanguage) {
 		document.getElementById('backTextControl').style.display='block';
 		document.getElementById('backText').style.display='block';
 		document.getElementById("backPaperWallet").innerHTML = translations[whichLanguage]['backPaperWallet'];
-		document.getElementById("backAmount").innerHTML = translations[whichLanguage]['backAmount'];
-		document.getElementById("backDate").innerHTML = translations[whichLanguage]['backDate'];
-		document.getElementById("backNotes").innerHTML = translations[whichLanguage]['backNotes'];
 		document.getElementById("backLongText").style.fontSize = translations[whichLanguage]['backLongTextFontSize'];
 		document.getElementById("backInst1").innerHTML = translations[whichLanguage]['backInst1'];
 		document.getElementById("backInst2").innerHTML = translations[whichLanguage]['backInst2'];


### PR DESCRIPTION
Default Instructions
====

![bitcoinpaperwallet new back](https://github.com/user-attachments/assets/7de0d370-9940-48e8-8379-3359ac7e78d9)

**Print**:

![bitcoin paper wallet new back how it prints](https://github.com/user-attachments/assets/b7e1eaa4-c632-4fe2-bab9-00ec806bc66b)

Custom Message
====

![bitcoin paper wallet new back custom](https://github.com/user-attachments/assets/fb636bcb-77ed-45f0-b5c8-64bbeed62c86)

**Print**

![bitcoin paper wallet new back custom how it prints](https://github.com/user-attachments/assets/5e3cd482-8407-4b42-b20d-545f4343a7e1)
